### PR TITLE
Update main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,52 +1,61 @@
-
 #[derive(Clone, Debug)]
-enum Coin {
-    Penny,
-    Nickel,
-    Dime,
-    Quarter,
+enum Currency {
+    OneCent,
+    FiveCents,
+    TenCents,
+    TwentyFiveCents,
 }
 
-impl Into<u8> for Coin {
+impl Currency {
+    fn value(&self) -> u8 {
+        match self {
+            Currency::OneCent => 1,
+            Currency::FiveCents => 5,
+            Currency::TenCents => 10,
+            Currency::TwentyFiveCents => 25,
+        }
+    }
+}
+
+impl Into<u8> for Currency {
     fn into(self) -> u8 {
-        match self {
-            Coin::Penny => 1,
-            Coin::Nickel => 5,
-            Coin::Dime => 10,
-            Coin::Quarter => 25,
-        }
+        self.value()
     }
 }
 
-impl Into<u16> for Coin {
+impl Into<u16> for Currency {
     fn into(self) -> u16 {
-        match self {
-            Coin::Penny => 1,
-            Coin::Nickel => 5,
-            Coin::Dime => 10,
-            Coin::Quarter => 25,
-        }
+        self.value() as u16
     }
 }
-
-impl TryFrom<u8> for Coin {
+impl TryFrom<u8> for Currency {
     type Error =  Box<dyn std::error::Error>;
 
-    fn try_from(value: u8) -> Result<Coin, Self::Error> {
+    fn try_from(value: u8) -> Result<Currency, Self::Error> {
         match value {
-            10 => Ok(Coin::Dime),
-            5 => Ok(Coin::Nickel),
-            25 => Ok(Coin::Quarter),
-            1 => Ok(Coin::Penny),
-            _ => Err("Error".into())
+            10 => Ok(Currency::TenCents),
+            5 => Ok(Currency::FiveCents),
+            25 => Ok(Currency::TwentyFiveCents),
+            1 => Ok(Currency::OneCent),
+            _ => Err("Invalid currency value".into())
         }
+    }
+}
+let n1 = Coin::try_from(19).expect("Invalid currency value");
+use std::fmt;
+
+impl fmt::Display for Currency {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 
 fn main() {
-    let value = Coin::Nickel;
+    let value = Currency::FiveCents;
     let number_u8: u8 = value.into();
-    let n1 = Coin::try_from(19).expect("Error");
+    let n1 = Currency::try_from(19).expect("Invalid currency value");
 
-    println!("{:?}", number_u8)
+    println!("Value: {}", value);
+    println!("Converted to u8: {}", number_u8);
+    println!("Try From 19: {}", n1);
 }


### PR DESCRIPTION
1-> Renomeie a enumeração Coin para Currency.
Utilizei nomes mais descritivos para as variantes, por exemplo, OneCent em vez de Penny.

2-> O método Into para u8 e u16 está repetitivo. Criei um método privado para evitar duplicação.

3-> Utilizei um tipo de erro específico em vez de uma string genérica.

4-> Melhorei a impressão usando um método fmt para Currency.